### PR TITLE
feat: add RPC failover to client

### DIFF
--- a/DeFiArbitraje/evm-arb-service/src/network.rs
+++ b/DeFiArbitraje/evm-arb-service/src/network.rs
@@ -1,12 +1,90 @@
 use crate::config::{Config, Network};
 use anyhow::{anyhow, Result};
-use ethers::providers::{Http, Provider};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use ethers::providers::{Http, Provider, ProviderError};
+use std::{
+    collections::HashMap,
+    future::Future,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tracing::warn;
 
 #[derive(Clone)]
 pub struct ChainClient {
     pub cfg: Network,
-    pub provider: Arc<Provider<Http>>,
+    endpoints: Vec<String>,
+    inner: Arc<Mutex<ClientState>>,
+}
+
+struct ClientState {
+    current_index: usize,
+    provider: Arc<Provider<Http>>,
+}
+
+impl ChainClient {
+    pub fn provider(&self) -> Arc<Provider<Http>> {
+        self.inner.lock().unwrap().provider.clone()
+    }
+
+    fn build_provider(url: &str) -> Result<Provider<Http>> {
+        let req_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(12))
+            .build()?;
+        let url: reqwest::Url = reqwest::Url::parse(url)?;
+        let http = Http::new_with_client(url, req_client);
+        Ok(Provider::new(http).interval(Duration::from_millis(500)))
+    }
+
+    fn switch_provider(&self) -> Result<()> {
+        let (next_idx, url) = {
+            let st = self.inner.lock().unwrap();
+            let next = (st.current_index + 1) % self.endpoints.len();
+            (next, self.endpoints[next].clone())
+        };
+
+        let provider = Arc::new(Self::build_provider(&url)?);
+        {
+            let mut st = self.inner.lock().unwrap();
+            st.current_index = next_idx;
+            st.provider = provider;
+        }
+        warn!("RPC failover to {url}");
+        Ok(())
+    }
+
+    fn is_retryable(err: &anyhow::Error) -> bool {
+        if let Some(pe) = err.downcast_ref::<ProviderError>() {
+            if let ProviderError::JsonRpcClientError(_) = pe {
+                return true;
+            }
+        }
+        if let Some(req_err) = err.downcast_ref::<reqwest::Error>() {
+            return req_err.is_timeout() || req_err.is_connect();
+        }
+        false
+    }
+
+    pub async fn with_failover<T, Fut, E>(&self, op: impl Fn(Arc<Provider<Http>>) -> Fut) -> Result<T>
+    where
+        Fut: Future<Output = Result<T, E>>,
+        E: Into<anyhow::Error> + Send + Sync + 'static,
+    {
+        let mut last_err: Option<anyhow::Error> = None;
+        for _ in 0..self.endpoints.len() {
+            let provider = self.provider();
+            match op(provider.clone()).await.map_err(|e| e.into()) {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    if !Self::is_retryable(&e) {
+                        return Err(e);
+                    }
+                    last_err = Some(e);
+                    self.switch_provider()?;
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| anyhow!("all RPC endpoints failed")))
+    }
 }
 
 #[derive(Clone)]
@@ -19,33 +97,26 @@ impl MultiChain {
         let mut map = HashMap::new();
 
         for n in &cfg.networks {
-            let rpc = n
-                .rpc
-                .get(0)
-                .ok_or_else(|| anyhow!("network '{}' has no RPC endpoints", n.name))?
-                .clone();
-
-            // reqwest-клиент с таймаутом
-            let req_client = reqwest::Client::builder()
-                .timeout(Duration::from_secs(12))
-                .build()?;
-
-            // Нужен именно reqwest::Url
-            let url: reqwest::Url = reqwest::Url::parse(&rpc)?;
-
-            // ПРАВИЛЬНЫЙ порядок: (url, client)
-            let http = Http::new_with_client(url, req_client);
-            let provider = Provider::new(http).interval(Duration::from_millis(500));
+            if n.rpc.is_empty() {
+                return Err(anyhow!("network '{}' has no RPC endpoints", n.name));
+            }
+            let provider = Arc::new(ChainClient::build_provider(&n.rpc[0])?);
 
             if map.contains_key(&n.chain_id) {
                 return Err(anyhow!("duplicate chain_id in config: {}", n.chain_id));
             }
 
+            let inner = ClientState {
+                current_index: 0,
+                provider,
+            };
+
             map.insert(
                 n.chain_id,
                 ChainClient {
                     cfg: n.clone(),
-                    provider: Arc::new(provider),
+                    endpoints: n.rpc.clone(),
+                    inner: Arc::new(Mutex::new(inner)),
                 },
             );
         }

--- a/DeFiArbitraje/evm-arb-service/src/route.rs
+++ b/DeFiArbitraje/evm-arb-service/src/route.rs
@@ -99,7 +99,7 @@ impl StrategyEngine {
                 continue;
             }
 
-            match signer_middleware_for_chain(client.provider.clone(), *chain_id) {
+            match signer_middleware_for_chain(client.provider(), *chain_id) {
                 Ok(signer_client) => {
                     let exec = Executor::new(signer_client.clone()).await?;
                     executors.insert(*chain_id, Arc::new(exec));
@@ -282,7 +282,7 @@ impl StrategyEngine {
                         .unwrap_or(18);
                     let amount_in = u256_from_decimals(1.0, dec);
                     if let Some(qr) = quote_cross_dex_pair(
-                        client.provider.clone(),
+                        &client,
                         &client.cfg,
                         (&r.pair[0], &r.pair[1]),
                         dex_a,


### PR DESCRIPTION
## Summary
- add failover-aware `ChainClient` that rotates among RPC endpoints
- wrap router on-chain calls with `with_failover`
- adapt route planner to new client API

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689f6c4deb8c8323856925044618c99c