### PR TITLE
feat: add strategy filters

### DIFF
--- a/DeFiArbitraje/evm-arb-service/src/config.rs
+++ b/DeFiArbitraje/evm-arb-service/src/config.rs
@@ -463,6 +463,12 @@ pub struct Strategy {
     #[serde(default)]
     pub search_space: Option<String>,
     #[serde(default)]
+    pub whitelist_dexes: Option<Vec<String>>,
+    #[serde(default)]
+    pub whitelist_pairs: Option<Vec<[String; 2]>>,
+    #[serde(default)]
+    pub only_stables: Option<bool>,
+    #[serde(default)]
     pub mev: Option<HashMap<String, serde_json::Value>>,
 }
 


### PR DESCRIPTION
## Summary
- extend Strategy with whitelist and stability fields
- filter routes and triangles by strategy constraints during scan

## Testing
- `cargo test -p DeFiArbitraje`


------
https://chatgpt.com/codex/tasks/task_e_689f72563c288323a1f06bf0947c3632