### PR TITLE
feat: add optional permit2 approvals

### DIFF
--- a/DeFiArbitraje/evm-arb-service/src/approvals.rs
+++ b/DeFiArbitraje/evm-arb-service/src/approvals.rs
@@ -9,12 +9,16 @@ use crate::config::Network;
 abigen!(
     IERC20,
     r#"[function allowance(address owner,address spender)view returns(uint256)
-                     function approve(address spender,uint256 amount) returns(bool)]"#
+                     function approve(address spender,uint256 amount) returns(bool)]"#,
+);
+abigen!(
+    IPermit2,
+    r#"[function approve(address token, address spender, uint160 amount, uint48 expiration, uint48 nonce)]"#,
 );
 
 pub async fn ensure_approvals<M, S>(
     sm: Arc<SignerMiddleware<M, S>>,
-    _net: &Network,
+    net: &Network,
     tokens: Vec<Address>,
     spenders: Vec<Address>,
     min_allowance: U256,
@@ -25,6 +29,14 @@ where
 {
     let me = sm.address();
     let dry = std::env::var("DRY_RUN").is_ok() || std::env::var("SAFE_LAUNCH").is_ok();
+    let permit2 = if net.permit2.is_empty() {
+        None
+    } else {
+        net.permit2.parse::<Address>().ok()
+    };
+    let permit2_max =
+        U256::from_str_radix("ffffffffffffffffffffffffffffffffffffffff", 16).unwrap_or(U256::MAX);
+    let permit2_exp: u64 = (1u64 << 48) - 1;
 
     for token in tokens {
         let c = IERC20::new(token, sm.clone());
@@ -32,16 +44,51 @@ where
             match c.allowance(me, *spender).call().await {
                 Ok(allowance) => {
                     if allowance < min_allowance {
-                        if dry {
-                            info!("DRY: approve token={:?} spender={:?}", token, spender);
-                        } else {
-                            let call = c.approve(*spender, U256::MAX).gas(60_000u64);
-                            let pending = call.send().await?;
-                            let tx = pending.tx_hash();
-                            info!(
-                                "approve sent token={:?} spender={:?} tx={:?}",
-                                token, spender, tx
-                            );
+                        let mut used_permit2 = false;
+                        if let Some(p2addr) = permit2 {
+                            if dry {
+                                info!(
+                                    "DRY: permit2 approve token={:?} spender={:?}",
+                                    token, spender
+                                );
+                                used_permit2 = true;
+                            } else {
+                                let p2 = IPermit2::new(p2addr, sm.clone());
+                                match p2
+                                    .approve(token, *spender, permit2_max, permit2_exp, 0u64)
+                                    .gas(80_000u64)
+                                    .send()
+                                    .await
+                                {
+                                    Ok(pending) => {
+                                        let tx = pending.tx_hash();
+                                        info!(
+                                            "permit2 approve sent token={:?} spender={:?} tx={:?}",
+                                            token, spender, tx
+                                        );
+                                        used_permit2 = true;
+                                    }
+                                    Err(e) => {
+                                        info!(
+                                            "permit2 approve failed token={:?} spender={:?} err={e:?}; falling back",
+                                            token, spender
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        if !used_permit2 {
+                            if dry {
+                                info!("DRY: approve token={:?} spender={:?}", token, spender);
+                            } else {
+                                let call = c.approve(*spender, U256::MAX).gas(60_000u64);
+                                let pending = call.send().await?;
+                                let tx = pending.tx_hash();
+                                info!(
+                                    "approve sent token={:?} spender={:?} tx={:?}",
+                                    token, spender, tx
+                                );
+                            }
                         }
                     } else {
                         debug!("allowance ok token={:?} spender={:?}", token, spender);

--- a/DeFiArbitraje/evm-arb-service/src/config.rs
+++ b/DeFiArbitraje/evm-arb-service/src/config.rs
@@ -94,9 +94,17 @@ impl Config {
                     *s = s.trim().to_uppercase();
                 }
             }
+            if !net.permit2.is_empty() {
+                net.permit2 = net.permit2.trim().to_lowercase();
+            }
         }
         if !self.global.risk.permit2.is_empty() {
             self.global.risk.permit2 = self.global.risk.permit2.trim().to_lowercase();
+            for net in &mut self.networks {
+                if net.permit2.is_empty() {
+                    net.permit2 = self.global.risk.permit2.clone();
+                }
+            }
         }
     }
 
@@ -146,6 +154,9 @@ impl Config {
             }
             if n.rpc.is_empty() {
                 return Err(anyhow!("network '{}' has no rpc endpoints", n.name));
+            }
+            if !n.permit2.is_empty() && !is_hex_addr(&n.permit2) {
+                return Err(anyhow!("network '{}' permit2 must be 0x-address or empty", n.name));
             }
             // токены
             for (sym, t) in &n.tokens {
@@ -396,6 +407,8 @@ pub struct Network {
     pub routes_cross_dex: Option<Vec<RouteDex>>,
     #[serde(default)]
     pub strategy_overrides: Option<StrategyOverrides>,
+    #[serde(default)]
+    pub permit2: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- use Permit2 contract for approvals when configured and fall back to ERC20 approvals
- allow networks to override or inherit global Permit2 address

## Testing
- `cargo test -p DeFiArbitraje`

------
https://chatgpt.com/codex/tasks/task_e_689f75bef0d0832389732685485bbe8d