### PR TITLE
docs: document run profile and env flags

### DIFF
--- a/DeFiArbitraje/README.md
+++ b/DeFiArbitraje/README.md
@@ -11,6 +11,26 @@ RUST_LOG=info ./target/debug/evm-arb-service /mnt/data/defi_config.json
 Использует `defi_config.json` (создан ранее). Адреса экзекутора передаются через ENV:
 - `EXECUTOR_8453`, `EXECUTOR_42161`, `EXECUTOR_56`, `EXECUTOR_10`, `EXECUTOR_137`
 
+## Запуск и ENV
+- `DRY_RUN=1` или `SAFE_LAUNCH=1` — не отправлять approve/execute, но писать кандидатов в `logs/` и вызывать `simulate`.
+- `EXECUTOR_<chainId>` — адрес on-chain экзекутора для каждой сети (например, `EXECUTOR_8453`).
+- `PRIVATE_KEY` или `PRIVATE_KEY_<chainId>` — ключ для подписи транзакций.
+
+### Примеры
+PowerShell:
+```powershell
+$env:DRY_RUN="1"
+$env:EXECUTOR_8453="0xabc..."
+$env:PRIVATE_KEY="0xdef..."
+RUST_LOG=info cargo run -p evm-arb-service -- ..\defi_config.json
+```
+
+Bash:
+```bash
+DRY_RUN=1 EXECUTOR_8453=0xabc... PRIVATE_KEY=0xdef... \
+  RUST_LOG=info cargo run -p evm-arb-service -- ./defi_config.json
+```
+
 ## Что реализовано
 - Загрузка конфига, мультисеть, скан кандидатов (pairs/routes/triangles)
 - Квоты: v2 getReserves, упрощённый v3 (slot0+liq), Solidly getAmountOut (если доступен pair)

--- a/DeFiArbitraje/evm-arb-service/src/approvals.rs
+++ b/DeFiArbitraje/evm-arb-service/src/approvals.rs
@@ -28,7 +28,10 @@ where
     S: Signer + 'static,
 {
     let me = sm.address();
-    let dry = std::env::var("DRY_RUN").is_ok() || std::env::var("SAFE_LAUNCH").is_ok();
+    let dry = std::env::var("DRY_RUN").map(|v| v == "1").unwrap_or(false)
+        || std::env::var("SAFE_LAUNCH")
+            .map(|v| v == "1")
+            .unwrap_or(false);
     let permit2 = if net.permit2.is_empty() {
         None
     } else {


### PR DESCRIPTION
## Summary
- explain run profiles and environment flags in README
- gate approval transactions behind explicit DRY_RUN/SAFE_LAUNCH=1

## Testing
- `cargo test` *(fails: use of unresolved module `chrono` in pool-discovery-cli)*
- `cargo test -p DeFiArbitraje`


------
https://chatgpt.com/codex/tasks/task_e_689f7baecea48323aa5f44553a698cef